### PR TITLE
Transactions serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# hey it appears that fast_jsonapi has halted development and its successor is jsonapi-serializer!
 gem 'fast_jsonapi', '~> 1.5'
 
 group :development, :test do

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,2 +1,7 @@
 class Api::V1::TransactionsController < ApplicationController
+  def index
+    transactions = Transaction.all
+    # render json: transactions, include: :fund
+    render json: TransactionSerializer.new(transactions)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,2 @@
 class ApplicationController < ActionController::API
-  def index
-    transactions = Transaction.all
-    render json: transactions, include: :fund
-  end
 end

--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,0 +1,4 @@
+class TransactionSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :recipient, :contact, :amount, :date, :notes, :fund
+end


### PR DESCRIPTION
Generated Transaction serializer, modified controller action to use serialized output, added :fund to serializer to include the Fund that Transaction belongs_to, moved controller action from application_controller to api/v1/transactions_controller (oops).

While researching fast_jsonapi gem, realized that it is no longer maintained (two years now) and has been succeeded by jsonapi-serializer gem